### PR TITLE
Sync fork up to projecthorus/chasemapper v1.6.0

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,10 +14,20 @@ on:
 jobs:
   build:
     name: Build container image
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        platform: [linux/amd64, linux/386, linux/arm64, linux/arm/v6, linux/arm/v7]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/386
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm/v6
+            runner: ubuntu-24.04-arm
+          - platform: linux/arm/v7
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/chasemapper/__init__.py
+++ b/chasemapper/__init__.py
@@ -8,4 +8,4 @@
 
 # Now using Semantic Versioning (https://semver.org/)  MAJOR.MINOR.PATCH
 
-__version__ = "1.6.0-beta1"
+__version__ = "1.6.0"

--- a/chasemapper/__init__.py
+++ b/chasemapper/__init__.py
@@ -8,4 +8,4 @@
 
 # Now using Semantic Versioning (https://semver.org/)  MAJOR.MINOR.PATCH
 
-__version__ = "1.5.10"
+__version__ = "1.6.0-beta1"

--- a/chasemapper/geometry.py
+++ b/chasemapper/geometry.py
@@ -234,8 +234,13 @@ class GenericTrack(object):
             _heading_delta = (self.heading - self.prev_heading) % 360.0
             if _heading_delta >= 180.0:
                 _heading_delta -= 360.0
-            
-            self.turn_rate = abs(_heading_delta)/_time_delta
+
+            try:
+                self.turn_rate = abs(_heading_delta)/_time_delta
+            except ZeroDivisionError:
+                logging.warning(
+                    "Zero time-step encountered in turn rate calculation - are multiple receivers reporting telemetry simultaneously?"
+                )
 
             return self.turn_rate
 

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -505,6 +505,8 @@ def handle_modem_stats(data):
 #
 predictor = None
 predictor_semaphore = False
+# End time of the current offline GFS dataset, used to detect when it goes stale mid-session.
+predictor_model_end = None
 
 predictor_thread_running = True
 predictor_thread = None
@@ -525,15 +527,44 @@ def predictorThread():
     logging.info("Closed predictor loop.")
 
 
+def fallback_to_tawhiri(reason):
+    """ Fall back to online (Tawhiri) predictions, e.g. if GFS data is missing, stale, or failed to download. """
+    global predictor, predictor_thread, predictor_model_end, chasemapper_config
+
+    logging.warning("Falling back to online (Tawhiri) predictions - %s." % reason)
+    predictor = "Tawhiri"
+    predictor_model_end = None
+    chasemapper_config["offline_predictions"] = False
+    chasemapper_config["pred_model"] = "Tawhiri (Online - %s)" % reason
+    flask_emit_event(
+        "predictor_model_update", {"model": chasemapper_config["pred_model"]}
+    )
+
+    # Start up the predictor thread if it is not running.
+    if predictor_thread is None:
+        predictor_thread = Thread(target=predictorThread)
+        predictor_thread.start()
+
+
 def run_prediction():
     """ Run a Flight Path prediction """
-    global chasemapper_config, current_payloads, current_payload_tracks, predictor, predictor_semaphore
+    global chasemapper_config, current_payloads, current_payload_tracks, predictor, predictor_semaphore, predictor_model_end
 
     if chasemapper_config["pred_enabled"] == False:
         return
 
     if (chasemapper_config["offline_predictions"] == True) and (predictor == None):
         return
+
+    # If the offline predictor is in use, check the GFS dataset still covers the
+    # near future, and fall back to online predictions once it goes stale.
+    if (
+        (predictor is not None)
+        and (predictor != "Tawhiri")
+        and (predictor_model_end is not None)
+    ):
+        if (datetime.utcnow() + timedelta(hours=4)) > predictor_model_end:
+            fallback_to_tawhiri("GFS data expired")
 
     # Set the semaphore so we don't accidentally kill the predictor object while it's running.
     predictor_semaphore = True
@@ -741,7 +772,7 @@ def run_prediction():
 
 
 def initPredictor():
-    global predictor, predictor_thread, chasemapper_config, pred_settings
+    global predictor, predictor_thread, predictor_model_end, chasemapper_config, pred_settings
 
     if chasemapper_config["offline_predictions"]:
         # Attempt to initialize an Offline Predictor instance
@@ -753,9 +784,7 @@ def initPredictor():
             _model_age = gfs_model_age(pred_settings["gfs_path"])
             if _model_age == "Unknown":
                 logging.error("No GFS data in directory.")
-                chasemapper_config["pred_model"] = "No GFS Data."
-                flask_emit_event("predictor_model_update", {"model": "No GFS data."})
-                chasemapper_config["offline_predictions"] = False
+                fallback_to_tawhiri("No GFS data")
             else:
                 # Check model contains data to at least 4 hours into the future.
                 (_model_start, _model_end) = available_gfs(pred_settings["gfs_path"])
@@ -763,11 +792,7 @@ def initPredictor():
                 if (_model_now < _model_start) or (_model_now > _model_end):
                     # No suitable GFS data!
                     logging.error("GFS Data in directory does not cover now!")
-                    chasemapper_config["pred_model"] = "Old GFS Data."
-                    flask_emit_event(
-                        "predictor_model_update", {"model": "Old GFS data."}
-                    )
-                    chasemapper_config["offline_predictions"] = False
+                    fallback_to_tawhiri("Old GFS data")
 
                 else:
                     chasemapper_config["pred_model"] = _model_age + " (Offline)"
@@ -778,6 +803,7 @@ def initPredictor():
                         bin_path=pred_settings["pred_binary"],
                         gfs_path=pred_settings["gfs_path"],
                     )
+                    predictor_model_end = _model_end
 
                     # Start up the predictor thread if it is not running.
                     if predictor_thread == None:
@@ -790,10 +816,9 @@ def initPredictor():
         except Exception as e:
             traceback.print_exc()
             logging.error("Loading predictor failed: " + str(e))
-            flask_emit_event("predictor_model_update", {"model": "Failed - Check Log."})
-            chasemapper_config["pred_model"] = "Failed - Check Log."
             print("Loading Predictor failed.")
             predictor = None
+            fallback_to_tawhiri("Offline predictor failed to load")
 
     else:
         # No initialization required for the online predictor
@@ -810,7 +835,7 @@ def initPredictor():
 
 def model_download_finished(result):
     """ Callback for when the model download is finished """
-    global chasemapper_config
+    global chasemapper_config, predictor
     if result == "OK":
         # Downloader reported OK, restart the predictor.
         chasemapper_config["offline_predictions"] = True
@@ -818,6 +843,10 @@ def model_download_finished(result):
     else:
         # Downloader reported an error, pass on to the client.
         flask_emit_event("predictor_model_update", {"model": result})
+        # If we don't have a working offline predictor with current data, fall back
+        # to online predictions rather than leaving the predictor disabled.
+        if (predictor is None) or (predictor == "Tawhiri"):
+            fallback_to_tawhiri("Model download failed")
 
 
 @socketio.on("download_model", namespace="/chasemapper")

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -381,6 +381,19 @@ def handle_new_payload_position(data, log_position=True):
 
     _short_time = _time_dt.strftime("%H:%M:%S")
 
+    # Multiple receivers on the same network will each broadcast their own copy of
+    # a decoded packet, so the same telemetry (or an older, delayed frame) can arrive
+    # more than once. Discard anything that isn't newer than the last track point,
+    # otherwise the zero/negative time-step corrupts the ascent rate and turn rate.
+    if _callsign in current_payload_tracks:
+        _track_history = current_payload_tracks[_callsign].track_history
+        if len(_track_history) > 0 and _time_dt <= _track_history[-1][0]:
+            logging.debug(
+                "Discarding duplicate/out-of-order telemetry for %s (packet time %s, last track point %s)."
+                % (_callsign, _time_dt.isoformat(), _track_history[-1][0].isoformat())
+            )
+            return
+
     if _callsign not in current_payloads:
         # New callsign! Create entries in data stores.
         current_payload_tracks[_callsign] = GenericTrack(ascent_averaging=chasemapper_config["ascent_rate_averaging"])

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -563,7 +563,7 @@ def run_prediction():
         and (predictor != "Tawhiri")
         and (predictor_model_end is not None)
     ):
-        if (datetime.now(UTC) + timedelta(hours=4)) > predictor_model_end:
+        if (datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=4)) > predictor_model_end:
             fallback_to_tawhiri("GFS data expired")
 
     # Set the semaphore so we don't accidentally kill the predictor object while it's running.
@@ -788,7 +788,7 @@ def initPredictor():
             else:
                 # Check model contains data to at least 4 hours into the future.
                 (_model_start, _model_end) = available_gfs(pred_settings["gfs_path"])
-                _model_now = datetime.now(UTC) + timedelta(0, 60 * 60 * 4)
+                _model_now = datetime.now(UTC).replace(tzinfo=None) + timedelta(0, 60 * 60 * 4)
                 if (_model_now < _model_start) or (_model_now > _model_end):
                     # No suitable GFS data!
                     logging.error("GFS Data in directory does not cover now!")

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -21,7 +21,7 @@ import pytz
 import time
 import traceback
 from threading import Thread
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from dateutil.parser import parse
 
 from chasemapper import __version__ as CHASEMAPPER_VERSION
@@ -563,7 +563,7 @@ def run_prediction():
         and (predictor != "Tawhiri")
         and (predictor_model_end is not None)
     ):
-        if (datetime.utcnow() + timedelta(hours=4)) > predictor_model_end:
+        if (datetime.now(UTC) + timedelta(hours=4)) > predictor_model_end:
             fallback_to_tawhiri("GFS data expired")
 
     # Set the semaphore so we don't accidentally kill the predictor object while it's running.
@@ -788,7 +788,7 @@ def initPredictor():
             else:
                 # Check model contains data to at least 4 hours into the future.
                 (_model_start, _model_end) = available_gfs(pred_settings["gfs_path"])
-                _model_now = datetime.utcnow() + timedelta(0, 60 * 60 * 4)
+                _model_now = datetime.now(UTC) + timedelta(0, 60 * 60 * 4)
                 if (_model_now < _model_start) or (_model_now > _model_end):
                     # No suitable GFS data!
                     logging.error("GFS Data in directory does not cover now!")

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -1299,7 +1299,7 @@ class WebHandler(logging.Handler):
                 # Convert log record into a dictionary
                 log_data = {
                     "level": record.levelname,
-                    "timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "timestamp": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "msg": record.msg,
                 }
                 # Emit to all socket.io clients

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -21,7 +21,8 @@ import pytz
 import time
 import traceback
 from threading import Thread
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
+UTC = timezone.utc
 from dateutil.parser import parse
 
 from chasemapper import __version__ as CHASEMAPPER_VERSION
@@ -563,7 +564,7 @@ def run_prediction():
         and (predictor != "Tawhiri")
         and (predictor_model_end is not None)
     ):
-        if (datetime.now(UTC).replace(tzinfo=None) + timedelta(hours=4)) > predictor_model_end:
+        if (datetime.now(UTC) + timedelta(hours=4)) > predictor_model_end:
             fallback_to_tawhiri("GFS data expired")
 
     # Set the semaphore so we don't accidentally kill the predictor object while it's running.
@@ -788,7 +789,7 @@ def initPredictor():
             else:
                 # Check model contains data to at least 4 hours into the future.
                 (_model_start, _model_end) = available_gfs(pred_settings["gfs_path"])
-                _model_now = datetime.now(UTC).replace(tzinfo=None) + timedelta(0, 60 * 60 * 4)
+                _model_now = datetime.now(UTC) + timedelta(hours=4)
                 if (_model_now < _model_start) or (_model_now > _model_end):
                     # No suitable GFS data!
                     logging.error("GFS Data in directory does not cover now!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 eccodes
-cusfpredict
+cusfpredict>=0.3.0
 flask
 flask-socketio
 lxml

--- a/static/css/chasemapper.css
+++ b/static/css/chasemapper.css
@@ -1,10 +1,24 @@
 body {
     padding: 0;
     margin: 0;
+    overflow: hidden;
 }
-html, body, #map {
+html, body {
     height: 100%;
-    width: 100vw;
+    width: 100%;
+}
+/* Let the map use auto width so the sidebar plugin's left margin (mobile)
+   shrinks it instead of overflowing and pushing right-edge controls off-screen. */
+#map {
+    height: 100%;
+}
+
+/* Keep the top-right controls (layer selector, follow/zoom buttons) stacked above
+   the top-center summary table, so the expanded layer list isn't hidden behind it.
+   All Leaflet corners default to z-index:1000, and the top-center corner is added
+   later in the DOM, so it wins the tie without an explicit bump here. */
+.leaflet-control-container .leaflet-top.leaflet-right {
+    z-index: 1001;
 }
 
 .slimContainer {
@@ -189,3 +203,64 @@ html, body, #map {
 	flex-direction: row-reverse !important;
 	justify-content: space-between !important;
   }
+
+/* Sidebar slide-away handle is mobile-only; hidden on desktop. */
+#sidebarHandle {
+    display: none;
+}
+
+/* Mobile: hide lat/lon from telem table (visible on map) and speed from summary table */
+@media (max-width: 767px) {
+    #telem_table .tabulator-col[tabulator-field="lat"],
+    #telem_table .tabulator-col[tabulator-field="lon"],
+    #telem_table .tabulator-cell[tabulator-field="lat"],
+    #telem_table .tabulator-cell[tabulator-field="lon"] {
+        display: none !important;
+    }
+
+    #summary_table .tabulator-col[tabulator-field="speed"],
+    #summary_table .tabulator-cell[tabulator-field="speed"] {
+        display: none !important;
+    }
+
+    /* Animate the settings sidebar sliding in and out. */
+    #sidebar {
+        transition: transform 0.3s ease;
+    }
+    /* When stowed, slide the whole sidebar off-screen to the left... */
+    body.sidebar-stowed #sidebar {
+        transform: translateX(-100%);
+    }
+    /* ...and let the map reclaim the ~40px the tab strip normally reserves. */
+    body.sidebar-stowed #map.sidebar-map {
+        margin-left: 0 !important;
+    }
+
+    /* Thin handle at the left edge to bring the sidebar back. */
+    #sidebarHandle {
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: 0;
+        transform: translateY(-50%);
+        width: 22px;
+        height: 60px;
+        line-height: 60px;
+        text-align: center;
+        font-size: 20px;
+        color: #333;
+        background: #fff;
+        box-shadow: 0 1px 5px rgba(0, 0, 0, 0.65);
+        border-radius: 0 4px 4px 0;
+        z-index: 2001;
+        cursor: pointer;
+    }
+}
+
+/* Very small screens: also hide elevation from summary table */
+@media (max-width: 480px) {
+    #summary_table .tabulator-col[tabulator-field="elevation"],
+    #summary_table .tabulator-cell[tabulator-field="elevation"] {
+        display: none !important;
+    }
+}

--- a/static/js/tables.js
+++ b/static/js/tables.js
@@ -199,7 +199,7 @@ function initTables(){
         columns:[ //Define Table Columns
             {title:"Alt (m)", field:"alt", headerSort:false},
             {title:"Speed (kph)", field:"speed", headerSort:false},
-            {title:"Asc Rate (m/s)", field:"vel_v", headerSort:false},
+            {title:"Asc Rate", field:"vel_v", headerSort:false},
             {title:"Azimuth", field:"azimuth", headerSort:false},
             {title:"Elevation", field:"elevation", headerSort:false},
             {title:"Range", field:"range", headerSort:false},
@@ -259,7 +259,7 @@ function initTablesImperial(){
         columns:[ //Define Table Columns
             {title:"Alt (ft)", field:"alt", headerSort:false},
             {title:"Speed (mph)", field:"speed", headerSort:false},
-            {title:"Asc Rate (ft/min)", field:"vel_v", headerSort:false},
+            {title:"Asc Rate", field:"vel_v", headerSort:false},
             {title:"Azimuth", field:"azimuth", headerSort:false},
             {title:"Elevation", field:"elevation", headerSort:false},
             {title:"Range", field:"range", headerSort:false},

--- a/templates/index.html
+++ b/templates/index.html
@@ -537,7 +537,20 @@
 
             initTables();
 
-            
+            $('#sidebarHandle').click(function(){
+                var stowed = $('body').toggleClass('sidebar-stowed').hasClass('sidebar-stowed');
+                $('#sidebarHandle i').attr('class', stowed ? 'fa fa-angle-right' : 'fa fa-angle-left');
+                // Let Leaflet recalculate after the slide/margin transition completes.
+                setTimeout(function(){ map.invalidateSize(); }, 350);
+            });
+
+            // On mobile, start with the sidebar stowed away.
+            if (window.innerWidth < 768) {
+                $('body').addClass('sidebar-stowed');
+                setTimeout(function(){ map.invalidateSize(); }, 350);
+            }
+
+
             // Grab the recent archive of telemetry data
             // This should only ever be run once - on page load.
             $.ajax({
@@ -1074,5 +1087,7 @@
     </div>
 
     <div id="map" class="sidebar-map"></div>
+
+    <div id="sidebarHandle"><i class="fa fa-angle-right"></i></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Merges upstream `projecthorus/chasemapper` **v1.6.0** into this fork, bringing our codebase up to the 1.6 baseline while preserving all fork-specific/APRS features. Version is now `1.6.0.0` (fork's `MAJOR.MINOR.PATCH.HUY` scheme).

Upstream and our fork already shared history up to a common merge-base, so the only new upstream work to integrate was 8 files across 11 commits — a small, focused sync.

## Upstream 1.6.0 changes brought in

- **Predictor online (Tawhiri) fallback** with GFS model-age freshness checks (`horusmapper.py`)
- **Timezone-aware datetime handling** for the new `cusfpredict` (`>=0.3.0`) — fixes timezone problems in offline predictions
- **`geometry.py`** offset type-compare bug fix
- **Mobile-friendly UI** changes (`static/css/chasemapper.css`, `static/js/tables.js`, `templates/index.html`)
- `sondehub.py` minor update

## Conflict resolutions

| File | Resolution |
|------|-----------|
| `chasemapper/__init__.py` | Version → `1.6.0.0` (keeps fork's `.HUY` versioning scheme) |
| `requirements.txt` | Kept fork's `eccodes>=2.47.0` / `eccodeslib` and python-version-specific `cusfpredict` install; pinned the PyPI path to `cusfpredict>=0.3.0` to pull in the timezone fix |
| `.github/workflows/container.yml` | Kept fork's **arm64-only** Raspberry Pi build matrix (the fork deliberately replaced upstream's multi-arch merge job) |
| `horusmapper.py` | Adopted upstream's **timezone-aware** GFS comparison to stay consistent with the newly-merged `predictor_model_end` freshness check; kept the fork's `record.getMessage()` log-formatting improvement |

## Preserved fork features

All fork-specific files and features remain intact, e.g. APRS-IS (`aprsis.py`), geofence/recovery/KML overlays, KrakenSDR bearings, airspace cache, and the offline-map-tile tooling.

## Verification

- No conflict markers remain
- `python3 -m py_compile horusmapper.py chasemapper/__init__.py` passes
- Naive/aware datetime handling is now internally consistent across the offline predictor code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbMp5dQD8UbCX6zYwPj1Wo)_