### PR TITLE
Fix bugs found in repo review: APRS-IS speed units, abort prediction, state sync

### DIFF
--- a/chasemapper/airspace_cache.py
+++ b/chasemapper/airspace_cache.py
@@ -300,7 +300,9 @@ def force_refresh_all():
         _refresh_in_progress = True
 
     try:
-        results = {}
+        # Pre-populate so a worker that outlives the join timeout still
+        # leaves a (False) entry rather than a missing key.
+        results = {layer: False for layer in LAYERS}
         threads = []
 
         def worker(layer):

--- a/chasemapper/aprsis.py
+++ b/chasemapper/aprsis.py
@@ -40,6 +40,10 @@ class APRSISListener:
         self._lock = threading.Lock()
         self._running = False
         self._thread = None
+        # True while a login has been sent on a live socket; used by the
+        # UI status display, so it reflects the actual connection rather
+        # than just "listener exists".
+        self.connected = False
 
     def start(self):
         self._running = True
@@ -124,6 +128,7 @@ class APRSISListener:
                 sock.sendall(login_line.encode())
 
                 logging.info("APRS-IS: connected and filter sent")
+                self.connected = True
 
                 fh = sock.makefile("r", encoding="latin-1")
                 while self._running:
@@ -137,19 +142,22 @@ class APRSISListener:
                     if line.startswith("#"):
                         logging.info("APRS-IS server msg: %s" % line)
                         continue
-                    logging.info("APRS-IS RAW: %s" % line)
+                    logging.debug("APRS-IS RAW: %s" % line)
                     self._handle_line(line)
 
             except Exception as e:
                 if self._running:
                     logging.error("APRS-IS: connection error: %s" % e)
             finally:
+                self.connected = False
                 with self._lock:
+                    _sock = self._sock
                     self._sock = None
-                try:
-                    sock.close()
-                except Exception:
-                    pass
+                if _sock is not None:
+                    try:
+                        _sock.close()
+                    except Exception:
+                        pass
 
             if self._running:
                 logging.info("APRS-IS: reconnecting in 10s")
@@ -169,7 +177,7 @@ class APRSISListener:
         lat = packet.get("latitude")
         lon = packet.get("longitude")
 
-        logging.info(
+        logging.debug(
             "APRS-IS packet: from=%s | balloon_cs=%s active_car=%s",
             from_,
             self.balloon_callsigns,
@@ -183,8 +191,9 @@ class APRSISListener:
 
         if from_ in self.balloon_callsigns:
             try:
-                speed_mph = packet.get("speed")
-                speed_ms = round(speed_mph * 0.44704) if speed_mph is not None else -1
+                # aprslib normalises speed to km/h (knots * 1.852).
+                speed_kph = packet.get("speed")
+                speed_ms = round(speed_kph / 3.6) if speed_kph is not None else -1
 
                 heading = packet.get("course")
                 if heading is None:

--- a/chasemapper/car_track_cache.py
+++ b/chasemapper/car_track_cache.py
@@ -20,6 +20,7 @@ Design notes:
 - Atomic write (tmp + replace) so a crash mid-write can't corrupt cache.
 """
 
+import atexit
 import json
 import logging
 import os
@@ -148,6 +149,15 @@ def get_points():
         return list(_points)
 
 
+def flush():
+    """Write the current buffer to disk immediately (bypasses the throttle).
+    Registered as an atexit handler so the last WRITE_INTERVAL_SEC worth of
+    points isn't lost on shutdown."""
+    with _lock:
+        if _points:
+            _flush_locked()
+
+
 def clear():
     with _lock:
         _points.clear()
@@ -181,4 +191,5 @@ def start():
     _ensure_dir()
     with _lock:
         _load_from_disk()
+    atexit.register(flush)
     threading.Thread(target=_rollover_loop, daemon=True).start()

--- a/chasemapper/logread.py
+++ b/chasemapper/logread.py
@@ -47,9 +47,10 @@ def read_last_balloon_telemetry():
                 log = read_file("./log_files/" + file)
             except Exception as e:
                 logging.debug("Error reading file - maybe in use: %s" % str(e))
+                continue
 
             for _entry in log:
-                if _entry["log_type"] == "BALLOON TELEMETRY":
+                if _entry.get("log_type") == "BALLOON TELEMETRY":
                     telemetry_found = True
                     _last_telemetry = _entry
 

--- a/chasemapper/spot.py
+++ b/chasemapper/spot.py
@@ -32,8 +32,9 @@ SPOT_FEED_URL = (
     "{feed_id}/message.xml"
 )
 
-# SPOT's public API rate-limits at roughly 1 request / 2.5 minutes per feed.
-# 300s (5 min) is the recommended floor for basic tracking.
+# SPOT's public API rate-limits at roughly 1 request / 2.5 minutes (150 s)
+# per feed, so clamp the poll interval to that. The recommended default is
+# 300 s (5 min) — see spot_poll_interval in horusmapper.cfg.example.
 MIN_POLL_INTERVAL = 150
 
 

--- a/horusmapper.py
+++ b/horusmapper.py
@@ -12,6 +12,7 @@ if sys.version_info < (3, 6):
     print("CRITICAL - chasemapper requires Python 3.6 or newer!")
     sys.exit(1)
 
+import hmac
 import json
 import logging
 import math
@@ -60,7 +61,10 @@ from chasemapper import geofence as geofence_mod
 
 # Define Flask Application, and allow automatic reloading of templates for dev work
 app = flask.Flask(__name__)
-app.config["SECRET_KEY"] = "secret!"
+app.config["SECRET_KEY"] = os.urandom(24).hex()
+# Reject oversized request bodies before route handlers buffer them.
+# Largest legitimate upload is a geofence KML (capped at 5 MB in the route).
+app.config["MAX_CONTENT_LENGTH"] = 8 * 1024 * 1024
 app.config["TEMPLATES_AUTO_RELOAD"] = True
 app.jinja_env.auto_reload = True
 
@@ -233,7 +237,8 @@ RECOVERY_API_KEY = os.environ.get("RECOVERY_API_KEY", "")
 def _check_recovery_auth():
     if not RECOVERY_API_KEY:
         return None
-    if flask.request.headers.get("X-Recovery-Key") != RECOVERY_API_KEY:
+    _supplied = flask.request.headers.get("X-Recovery-Key", "")
+    if not hmac.compare_digest(_supplied, RECOVERY_API_KEY):
         return flask.jsonify({"error": "forbidden"}), 403
     return None
 
@@ -492,21 +497,6 @@ def sync_bearing_store_time_seq():
     )
 
 
-def sync_bearing_store_time_seq():
-    """Keep the bearing handler aligned with server-authoritative time-sequence settings."""
-    global bearing_store, chasemapper_config
-
-    if bearing_store is None:
-        return
-
-    bearing_store.update_time_sequence(
-        enabled=chasemapper_config["time_seq_enabled"],
-        times=chasemapper_config["time_seq_times"],
-        active=chasemapper_config["time_seq_active"],
-        cycle=chasemapper_config["time_seq_cycle"],
-    )
-
-
 def sync_bearing_store_confidence_threshold():
     """Keep the bearing handler aligned with server-authoritative confidence settings."""
     global bearing_store, chasemapper_config
@@ -521,7 +511,7 @@ def sync_bearing_store_confidence_threshold():
 
 @socketio.on("client_settings_update", namespace="/chasemapper")
 def client_settings_update(data):
-    global chasemapper_config, online_uploader
+    global chasemapper_config, online_uploader, predictor
 
     _predictor_change = "none"
     if (chasemapper_config["pred_enabled"] == False) and (data["pred_enabled"] == True):
@@ -598,7 +588,8 @@ def client_settings_update(data):
                 )
 
     elif _habitat_change == "stop":
-        online_uploader.close()
+        if online_uploader != None:
+            online_uploader.close()
         online_uploader = None
 
     # Update the habitat uploader with a new update rate, if one has changed.
@@ -748,6 +739,7 @@ def handle_new_payload_position(data, log_position=True):
 
     else:
         _vel_v = 0.0
+        _speed = 0.0
         _ttl = ""
 
     # Now update the main telemetry store.
@@ -1081,7 +1073,7 @@ def run_prediction():
                     descent_mode=_current_pos["is_descending"],
                 )
 
-            if len(_pred_path) > 1:
+            if len(_abort_pred_path) > 1:
                 # Valid Prediction!
                 _abort_pred_path.insert(0, _current_pos_list)
                 # Convert from predictor output format to a polyline.
@@ -1094,7 +1086,7 @@ def run_prediction():
 
                 _abort_pred_ok = True
                 logging.info(
-                    "Abort Prediction Updated, %d data points." % len(_pred_path)
+                    "Abort Prediction Updated, %d data points." % len(_abort_pred_path)
                 )
             else:
                 current_payloads[_payload]["abort_path"] = []
@@ -1260,6 +1252,10 @@ def clear_car_data(data):
     global car_track
     logging.warning("Client requested all chase car data be cleared.")
     car_track = GenericTrack()
+    # Re-apply configured gating thresholds, which the fresh GenericTrack
+    # would otherwise reset to its defaults.
+    car_track.heading_gate_threshold = chasemapper_config["car_speed_gate"]
+    car_track.turn_rate_threshold = chasemapper_config["turn_rate_threshold"]
     car_track_cache.clear()
 
 
@@ -1731,7 +1727,7 @@ def _aprsis_state():
         "active_car": p.get("aprsis_active_car_callsign", ""),
         "car_callsigns": p.get("aprsis_car_callsigns", []),
         "balloon_callsigns": p.get("aprsis_balloon_callsigns", []),
-        "connected": aprsis_listener is not None,
+        "connected": (aprsis_listener is not None) and aprsis_listener.connected,
     }
 
 
@@ -1747,6 +1743,9 @@ def aprsis_set_car_callsign(data):
         aprsis_listener.set_active_car_callsign(cs)
     logging.info("APRS-IS active car callsign: %s (profile %s)" % (cs, p.get("name")))
     flask_emit_event("aprsis_state", _aprsis_state())
+    # Also push the full settings so client-side config copies stay in sync;
+    # otherwise a later client_settings_update would clobber this change.
+    flask_emit_event("server_settings_update", chasemapper_config)
 
 
 @socketio.on("aprsis_add_car_callsign", namespace="/chasemapper")
@@ -1761,6 +1760,7 @@ def aprsis_add_car_callsign(data):
     if aprsis_listener is not None:
         aprsis_listener.add_car_callsign(cs)
     flask_emit_event("aprsis_state", _aprsis_state())
+    flask_emit_event("server_settings_update", chasemapper_config)
 
 
 @socketio.on("aprsis_add_balloon_callsign", namespace="/chasemapper")
@@ -1775,6 +1775,7 @@ def aprsis_add_balloon_callsign(data):
     if aprsis_listener is not None:
         aprsis_listener.add_balloon_callsign(cs)
     flask_emit_event("aprsis_state", _aprsis_state())
+    flask_emit_event("server_settings_update", chasemapper_config)
 
 
 @socketio.on("aprsis_remove_callsign", namespace="/chasemapper")
@@ -1796,6 +1797,7 @@ def aprsis_remove_callsign(data):
         if aprsis_listener is not None and new_active:
             aprsis_listener.set_active_car_callsign(new_active)
     flask_emit_event("aprsis_state", _aprsis_state())
+    flask_emit_event("server_settings_update", chasemapper_config)
 
 
 @socketio.on("device_position", namespace="/chasemapper")


### PR DESCRIPTION
Fork-specific fixes:
- aprsis: convert speed from km/h (aprslib's normalised unit) to m/s
  instead of treating it as mph, which overestimated by ~61%
- aprsis: demote per-packet log lines to DEBUG so they no longer flood
  the web client log panel via WebHandler
- aprsis: track a real 'connected' flag so the UI status reflects the
  actual socket state, not just listener existence; also avoid touching
  a potentially-unbound socket variable in the reconnect loop
- horusmapper: remove duplicate sync_bearing_store_time_seq definition
- horusmapper: re-apply car_speed_gate / turn_rate_threshold after
  'clear car data' recreates the GenericTrack
- horusmapper: broadcast server_settings_update after APRS-IS callsign
  mutations so stale client config copies can't clobber them on save
- car_track_cache: flush buffer to disk at exit so the last
  WRITE_INTERVAL_SEC of track points survives a restart
- airspace_cache: pre-populate force_refresh_all results so slow
  workers leave a False entry instead of a missing key
- spot: fix comment contradicting MIN_POLL_INTERVAL

Inherited upstream fixes:
- horusmapper: abort prediction validity checked len(_pred_path)
  instead of len(_abort_pred_path), publishing a bogus single-point
  abort landing when only the main prediction succeeded
- horusmapper: add missing 'global predictor' so disabling predictions
  actually releases the predictor
- horusmapper: guard online_uploader.close() against None on stop
- horusmapper: set _speed in the no-state fallback branch to avoid a
  latent NameError
- logread: skip unreadable log files instead of iterating an unbound
  variable; use .get() for log_type

Hardening:
- randomise Flask SECRET_KEY at startup
- set MAX_CONTENT_LENGTH (8 MB) to reject oversized request bodies
- constant-time comparison for X-Recovery-Key

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q4aKn822SD62MSVVRSsFKV